### PR TITLE
Use print-as-a-function for Py3 compat

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -20,4 +20,4 @@ nb = MultinomialNB()
 nb.fit(counts, fixed_target)
 
 print(nb.predict(count_vect.transform(["I love my iphone!!!"])))
-#print nb.predict(count_vect.transform(["iphone cost too much!!!"]))
+#print(nb.predict(count_vect.transform(["iphone cost too much!!!"])))

--- a/classifier.py
+++ b/classifier.py
@@ -19,5 +19,5 @@ from sklearn.naive_bayes import MultinomialNB
 nb = MultinomialNB()
 nb.fit(counts, fixed_target)
 
-print nb.predict(count_vect.transform(["I love my iphone!!!"]))
+print(nb.predict(count_vect.transform(["I love my iphone!!!"])))
 #print nb.predict(count_vect.transform(["iphone cost too much!!!"]))

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -9,4 +9,4 @@ from sklearn.feature_extraction.text import CountVectorizer
 count_vect = CountVectorizer()
 count_vect.fit(text)
 
-print count_vect.vocabulary_.get(u'3g')
+print(count_vect.vocabulary_.get(u'3g'))

--- a/feature_extraction_2.py
+++ b/feature_extraction_2.py
@@ -13,4 +13,4 @@ from sklearn.feature_extraction.text import CountVectorizer
 count_vect = CountVectorizer()
 count_vect.fit(fixed_text)
 
-print count_vect.vocabulary_.get(u'3g')
+print(count_vect.vocabulary_.get(u'3g'))

--- a/feature_extraction_3.py
+++ b/feature_extraction_3.py
@@ -15,4 +15,4 @@ count_vect.fit(fixed_text)
 
 counts = count_vect.transform(fixed_text)
 
-print count_vect.transform(["I love my iphone!!!"])
+print(count_vect.transform(["I love my iphone!!!"]))

--- a/feature_selection.py
+++ b/feature_selection.py
@@ -24,5 +24,5 @@ p.fit(fixed_text, fixed_target)
 from sklearn import cross_validation
 
 scores = cross_validation.cross_val_score(p, fixed_text, fixed_target, cv=10)
-print scores
-print scores.mean()
+print(scores)
+print(scores.mean())

--- a/load_data.py
+++ b/load_data.py
@@ -6,5 +6,5 @@ df = pd.read_csv('tweets.csv')
 target = df['is_there_an_emotion_directed_at_a_brand_or_product']
 text = df['tweet_text']
 
-print target[0:5]
-print text[0:5]
+print(target[0:5])
+print(text[0:5])

--- a/ngrams.py
+++ b/ngrams.py
@@ -17,4 +17,4 @@ p = Pipeline(steps=[('counts', CountVectorizer(ngram_range=(1, 2))),
                 ('multinomialnb', MultinomialNB())])
 
 p.fit(fixed_text, fixed_target)
-print p.predict(["I love my iphone!"])
+print(p.predict(["I love my iphone!"]))

--- a/pipeline.py
+++ b/pipeline.py
@@ -17,4 +17,4 @@ p = Pipeline(steps=[('counts', CountVectorizer()),
                 ('multinomialnb', MultinomialNB())])
 
 p.fit(fixed_text, fixed_target)
-print p.predict(["I love my iphone!"])
+print(p.predict(["I love my iphone!"]))

--- a/pipeline_bigrams.py
+++ b/pipeline_bigrams.py
@@ -17,5 +17,5 @@ p = Pipeline(steps=[('counts', CountVectorizer(ngram_range=(1, 2))),
                 ('multinomialnb', MultinomialNB())])
 
 p.fit(fixed_text, fixed_target)
-print p.named_steps['counts'].vocabulary_.get(u'garage sale')
-print len(p.named_steps['counts'].vocabulary_)
+print(p.named_steps['counts'].vocabulary_.get(u'garage sale'))
+print(len(p.named_steps['counts'].vocabulary_))

--- a/pipeline_bigrams_cross_validate.py
+++ b/pipeline_bigrams_cross_validate.py
@@ -21,5 +21,5 @@ p.fit(fixed_text, fixed_target)
 from sklearn import cross_validation
 
 scores = cross_validation.cross_val_score(p, fixed_text, fixed_target, cv=10)
-print scores
-print scores.mean()
+print(scores)
+print(scores.mean())

--- a/test_algorithm_1.py
+++ b/test_algorithm_1.py
@@ -20,4 +20,4 @@ nb = MultinomialNB()
 nb.fit(counts, fixed_target)
 
 predictions = nb.predict(counts)
-print sum(predictions == fixed_target)
+print(sum(predictions == fixed_target))

--- a/test_algorithm_2.py
+++ b/test_algorithm_2.py
@@ -21,4 +21,4 @@ nb = MultinomialNB()
 nb.fit(counts[0:6000], fixed_target[0:6000])
 
 predictions = nb.predict(counts[6000:9092])
-print sum(predictions == fixed_target[6000:9092])
+print(sum(predictions == fixed_target[6000:9092]))

--- a/test_algorithm_cross_validation.py
+++ b/test_algorithm_cross_validation.py
@@ -21,5 +21,5 @@ nb = MultinomialNB()
 from sklearn import cross_validation
 
 scores = cross_validation.cross_val_score(nb, counts, fixed_target, cv=10)
-print scores
-print scores.mean()
+print(scores)
+print(scores.mean())

--- a/test_algorithm_cross_validation_dummy.py
+++ b/test_algorithm_cross_validation_dummy.py
@@ -23,5 +23,5 @@ nb = DummyClassifier(strategy='most_frequent')
 from sklearn import cross_validation
 
 scores = cross_validation.cross_val_score(nb, counts, fixed_target, cv=10)
-print scores
-print scores.mean()
+print(scores)
+print(scores.mean())

--- a/test_algorithm_dummy.py
+++ b/test_algorithm_dummy.py
@@ -23,4 +23,4 @@ nb = DummyClassifier(strategy='most_frequent')
 nb.fit(counts[0:6000], fixed_target[0:6000])
 
 predictions = nb.predict(counts[6000:9092])
-print sum(predictions == fixed_target[6000:9092])
+print(sum(predictions == fixed_target[6000:9092]))


### PR DESCRIPTION
This pull request uses parentheses around all print statements, so that the code works as expected in Python 3 (and in Python 2.6+).
