### PR TITLE
[README] Remove broken path in testing python test-keras.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ python test-scikit.py
 You should see the output "Scikit is installed!"
 
 ```
-python keras-transfer/test-keras.py
+python test-keras.py
 ```
 
 You should see the output "Using TensorFlow backend.  Keras is installed!"


### PR DESCRIPTION
Fixing broken path in readme. The `test-keras.py` isn't in a `keras-transfer` directory, but in root directory instead. So, I remove the directory in README.
