### PR TITLE
update to compatible version of keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow
-keras
+keras==2.2.0
 pandas
 numpy
 pillow


### PR DESCRIPTION
keras 2.2.3 threw error `KeyError: 'Cannot set attribute. Group with name "keras_version" exists.'`