### PR TITLE
fixes mlp.py code to match video, run correctly

### DIFF
--- a/videos/mlp/mlp.py
+++ b/videos/mlp/mlp.py
@@ -12,6 +12,8 @@ import wandb
 run = wandb.init()
 config = run.config
 
+config.epochs = 10
+config.optimizer = "adam"
 config.hidden_nodes = 100
 
 # load data
@@ -41,6 +43,6 @@ model.compile(loss='categorical_crossentropy', optimizer=config.optimizer,
                     metrics=['accuracy'])
 
 # Fit the model
-model.fit(X_train, y_train, validation_data=(X_test, y_test), 
+model.fit(X_train, y_train, validation_data=(X_test, y_test),
       epochs=config.epochs,
       callbacks=[WandbCallback(validation_data=X_test, labels=labels)])


### PR DESCRIPTION
`videos/mlp/mlp.py` does not run as written, as it is missing two lines that set the `config` values correctly.

This PR would add those lines back in, matching the video.