### PR TITLE
fixes deprecated APIs in wandb and keras

### DIFF
--- a/videos/autoencoder/autoencoder.py
+++ b/videos/autoencoder/autoencoder.py
@@ -27,20 +27,23 @@ model.compile(optimizer='adam', loss='mse')
 
 # For visualization
 class Images(Callback):
+      def __init__(self, validation_data):
+            self.validation_data = validation_data
+
       def on_epoch_end(self, epoch, logs):
             indices = np.random.randint(self.validation_data[0].shape[0], size=8)
             test_data = self.validation_data[0][indices]
             pred_data = self.model.predict(test_data)
-            run.history.row.update({
+            wandb.log({
                   "examples": [
                         wandb.Image(np.hstack([data, pred_data[i]]), caption=str(i))
-                        for i, data in enumerate(test_data)]
-            })
+                        for i, data in enumerate(test_data)]},
+                  step=epoch)
 
 model.fit(x_train, x_train,
                 epochs=config.epochs,
-                validation_data=(x_test, x_test), 
-          callbacks=[Images(), WandbCallback()])
+                validation_data=(x_test, x_test),
+          callbacks=[Images((x_test, x_test)), WandbCallback()])
 
 
 model.save('auto.h5')

--- a/videos/autoencoder/autoencoder_cnn.py
+++ b/videos/autoencoder/autoencoder_cnn.py
@@ -10,7 +10,7 @@ from wandb.keras import WandbCallback
 run = wandb.init()
 config = run.config
 
-config.epochs = 100
+config.epochs = 2
 
 (x_train, _), (x_test, _) = mnist.load_data()
 
@@ -23,28 +23,32 @@ model.add(Conv2D(32, (3, 3), activation='relu', padding='same'))
 model.add(MaxPooling2D(2,2))
 model.add(Conv2D(32, (3, 3), activation='relu', padding='same'))
 model.add(UpSampling2D((2, 2)))
-model.add(Conv2D(1, (3, 3), activation='relu', padding='same'))
+model.add(Conv2D(1, (3, 3), activation='sigmoid', padding='same'))
 model.add(Reshape((28,28)))
 
 model.compile(optimizer='adam', loss='mse')
 
 model.summary()
 
+# For visualization
 class Images(Callback):
+      def __init__(self, validation_data):
+            self.validation_data = validation_data
+
       def on_epoch_end(self, epoch, logs):
             indices = np.random.randint(self.validation_data[0].shape[0], size=8)
             test_data = self.validation_data[0][indices]
             pred_data = self.model.predict(test_data)
-            run.history.row.update({
+            wandb.log({
                   "examples": [
                         wandb.Image(np.hstack([data, pred_data[i]]), caption=str(i))
-                        for i, data in enumerate(test_data)]
-            })
+                        for i, data in enumerate(test_data)]},
+                  step=epoch)
 
 model.fit(x_train, x_train,
                 epochs=config.epochs,
-                validation_data=(x_test, x_test), 
-                callbacks=[Images(), WandbCallback()])
+                validation_data=(x_test, x_test),
+          callbacks=[Images((x_test, x_test)), WandbCallback()])
 
 
 model.save('auto-cnn.h5')

--- a/videos/autoencoder/denoising_autoencoder.py
+++ b/videos/autoencoder/denoising_autoencoder.py
@@ -36,22 +36,25 @@ model.add(Dense(784, activation='sigmoid'))
 model.add(Reshape((28,28)))
 model.compile(optimizer='adam', loss='mse')
 
-#for visualization
+# For visualization
 class Images(Callback):
+      def __init__(self, validation_data):
+            self.validation_data = validation_data
+
       def on_epoch_end(self, epoch, logs):
             indices = np.random.randint(self.validation_data[0].shape[0], size=8)
             test_data = self.validation_data[0][indices]
             pred_data = self.model.predict(test_data)
-            run.history.row.update({
+            wandb.log({
                   "examples": [
                         wandb.Image(np.hstack([data, pred_data[i]]), caption=str(i))
-                        for i, data in enumerate(test_data)]
-            })
-
+                        for i, data in enumerate(test_data)]},
+                  step=epoch)
 
 model.fit(x_train_noisy, x_train,
                 epochs=config.epochs,
-                validation_data=(x_test_noisy, x_test), callbacks=[Images(), WandbCallback()])
+                validation_data=(x_test_noisy, x_test),
+          callbacks=[Images((x_test_noisy, x_test)), WandbCallback()])
 
 
 model.save("auto-denoise.h5")


### PR DESCRIPTION
the accessing `validation_data` from `Callback.validation_data` [has been deprecated](https://github.com/tensorflow/tensorflow/issues/36375).

also, i believe we've changed how we log Media to runs, so `run.history.update` is no longer the move.

this PR will fix both of these issues, which strike the `Images` Callback in the autoencoder video.