### PR TITLE
removes unnecessary call to .fit before cross-validating

### DIFF
--- a/examples/scikit/pipeline-bigrams-cross-validate.py
+++ b/examples/scikit/pipeline-bigrams-cross-validate.py
@@ -16,8 +16,6 @@ from sklearn.pipeline import Pipeline
 p = Pipeline(steps=[('counts', CountVectorizer(ngram_range=(1, 1))),
                 ('multinomialnb', MultinomialNB())])
 
-p.fit(fixed_text, fixed_target)
-
 from sklearn.model_selection import cross_val_score
 
 scores = cross_val_score(p, fixed_text, fixed_target, cv=10)


### PR DESCRIPTION
closes #30 by removing the unnecessary call.