### PR TITLE
fixes the cnn-text example, closes #39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ wandb-debug.log
 keras-sign/sign-language
 **/__pycache__
 **/.ipynb_checkpoints
+**/glove*
+**/aclImdb/

--- a/videos/cnn-text/download-imdb.py
+++ b/videos/cnn-text/download-imdb.py
@@ -1,26 +1,29 @@
 import os
+import shutil
+import sys
+import tempfile
+import urllib.request
 
-def load_imdb():
-    X_train = []
-    y_train = []
 
-    path = './aclImdb/train/pos/'
-    X_train.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
-    y_train.extend([1 for _ in range(12500)])
+IMDB_URL = "https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz"
+OUTPUT_NAME = "aclImdb"
 
-    path = './aclImdb/train/neg/'
-    X_train.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
-    y_train.extend([0 for _ in range(12500)])
+def main():
+    download_and_extract_archive()
 
-    X_test = []
-    y_test = []
-    
-    path = './aclImdb/test/pos/'
-    X_test.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
-    y_test.extend([1 for _ in range(12500)])
 
-    path = './aclImdb/test/neg/'
-    X_test.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
-    y_test.extend([0 for _ in range(12500)])
-    
-    return (X_train, y_train), (X_test, y_test)
+def download_and_extract_archive():
+    if os.path.exists(OUTPUT_NAME):
+        print("Imdb dataset download target exists at " + OUTPUT_NAME)
+    else:
+        with urllib.request.urlopen(IMDB_URL) as response:
+            with tempfile.NamedTemporaryFile() as temp_archive:
+                temp_archive.write(response.read())
+                imdb_tar = shutil.unpack_archive(
+                    temp_archive.name, extract_dir=".", format="gztar")
+
+    return
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/videos/cnn-text/imdb-cnn.py
+++ b/videos/cnn-text/imdb-cnn.py
@@ -9,6 +9,8 @@ from wandb.keras import WandbCallback
 import numpy as np
 from keras.preprocessing import text
 
+import imdb
+
 wandb.init()
 config = wandb.config
 
@@ -22,7 +24,13 @@ config.kernel_size = 3
 config.hidden_dims = 250
 config.epochs = 10
 
-(X_train, y_train), (X_test, y_test) = imdb.load_data(num_words=config.vocab_size, maxlen=config.maxlen)
+(X_train, y_train), (X_test, y_test) = imdb.load_imdb()
+
+
+tokenizer = text.Tokenizer(num_words=config.vocab_size)
+tokenizer.fit_on_texts(X_train)
+X_train = tokenizer.texts_to_matrix(X_train)
+X_test = tokenizer.texts_to_matrix(X_test)
 
 X_train = sequence.pad_sequences(X_train, maxlen=config.maxlen)
 X_test = sequence.pad_sequences(X_test, maxlen=config.maxlen)

--- a/videos/cnn-text/imdb-embedding.py
+++ b/videos/cnn-text/imdb-embedding.py
@@ -1,18 +1,18 @@
 # need to download glove from http://nlp.stanford.edu/data/glove.6B.zip
 # wget http://nlp.stanford.edu/data/glove.6B.zip
-# unzip http://nlp.stanford.edu/data/glove.6B.zip
+# unzip glove.6B.zip
 
 from keras.preprocessing import sequence
 from keras.models import Sequential
 from keras.layers import Dense, Dropout, Activation
 from keras.layers import Embedding, LSTM
 from keras.layers import Conv1D, Flatten, MaxPooling1D
-from keras.datasets import imdb
 import wandb
 from wandb.keras import WandbCallback
-import imdb
 import numpy as np
 from keras.preprocessing import text
+
+import imdb
 
 wandb.init()
 config = wandb.config

--- a/videos/cnn-text/imdb.py
+++ b/videos/cnn-text/imdb.py
@@ -1,26 +1,32 @@
+import numpy as np
 import os
+
+sep = os.path.sep
 
 def load_imdb():
     X_train = []
     y_train = []
 
-    path = './aclImdb/train/pos/'
+    path = os.path.join('aclImdb', 'train', 'pos', '')
     X_train.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
     y_train.extend([1 for _ in range(12500)])
 
-    path = './aclImdb/train/neg/'
+    path = os.path.join('aclImdb', 'train', 'neg', '')
     X_train.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
     y_train.extend([0 for _ in range(12500)])
 
     X_test = []
     y_test = []
-    
-    path = './aclImdb/test/pos/'
+
+    path = os.path.join('aclImdb', 'test', 'pos', '')
     X_test.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
     y_test.extend([1 for _ in range(12500)])
 
-    path = './aclImdb/test/neg/'
+    path = os.path.join('aclImdb', 'test', 'neg', '')
     X_test.extend([open(path + f).read() for f in os.listdir(path) if f.endswith('.txt')])
     y_test.extend([0 for _ in range(12500)])
-    
+
+    y_train = np.array(y_train, dtype=np.int32)
+    y_test = np.array(y_test, dtype=np.int32)
+
     return (X_train, y_train), (X_test, y_test)


### PR DESCRIPTION
This was a fun one! The `videos/cnn-text` example got a bit mangled: one of the examples was using a different version of the dataset (downloaded from Keras) than the other (using a hand-rolled downloader), and the hand-rolled downloader was missing!

I rewrote it (`download-imdb.py`) and the data loading code (`imdb.py`) to remove some bugs and do my best to make them OS-independent.

Also, the differences in setup meant that the code had been changed since the video. I reverted it and confirmed that we could get good performance.